### PR TITLE
refactor hard code

### DIFF
--- a/advisor/index.go
+++ b/advisor/index.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	// https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+	// IndexNameMaxLength Ref. https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
 	IndexNameMaxLength = 64
 )
 
@@ -562,7 +562,7 @@ func (idxAdv *IndexAdvisor) mergeIndexes(idxList []IndexInfo) []IndexInfo {
 			// 检测索引名称是否重复?
 			if existedIndexes := indexMeta.FindIndex(database.IndexKeyName, idx.Name); len(existedIndexes) > 0 {
 				var newName string
-				idxSuffix := getIndexNameSuffix()
+				idxSuffix := getRandomIndexSuffix()
 				if len(idx.Name) < IndexNameMaxLength-len(idxSuffix) {
 					newName = idx.Name + idxSuffix
 				} else {
@@ -584,7 +584,8 @@ func (idxAdv *IndexAdvisor) mergeIndexes(idxList []IndexInfo) []IndexInfo {
 	return rmSelfDupIndex(indexes)
 }
 
-func getIndexNameSuffix() string {
+// getRandomIndexSuffix format: _xxxx, length: 5
+func getRandomIndexSuffix() string {
 	return fmt.Sprintf("_%s", uniuri.New()[:4])
 }
 

--- a/advisor/index_test.go
+++ b/advisor/index_test.go
@@ -19,6 +19,7 @@ package advisor
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/XiaoMi/soar/common"
@@ -461,6 +462,15 @@ func TestIdxColsTypeCheck(t *testing.T) {
 					t.Error(pretty.Sprint(rule))
 				}
 			}
+		}
+	}
+}
+
+func TestGetRandomIndexSuffix(t *testing.T) {
+	for i := 0; i < 5; i++ {
+		r := getRandomIndexSuffix()
+		if !(strings.HasPrefix(r, "_") && len(r) == 5) {
+			t.Errorf("getRandomIndexSuffix should return a string with prefix `_` and 5 length, but got:%s", r)
 		}
 	}
 }


### PR DESCRIPTION
- use `IndexNameMaxLength` instead of hard code `64`
- use function `getIndexNameSuffix`  to generate index name suffix  without worry about changes later. 