### PR TITLE
 采用tidb解析器替换vitess 解决vitess 无法解析rename 语句库名/表名的问题

### DIFF
--- a/ast/pretty.go
+++ b/ast/pretty.go
@@ -41,7 +41,7 @@ func Pretty(sql string, method string) (output string) {
 
 	switch method {
 	case "builtin", "markdown":
-		return format(sql)
+		return PrettyFormat(sql)
 	default:
 		return sql
 	}
@@ -50,7 +50,7 @@ func Pretty(sql string, method string) (output string) {
 // format the whitespace in a SQL string to make it easier to read.
 // @param string  $query    The SQL string
 // @return String The SQL string with HTML styles and formatting wrapped in a <pre> tag
-func format(query string) string {
+func PrettyFormat(query string) string {
 	// This variable will be populated with formatted html
 	result := ""
 	// Use an actual tab while formatting and then switch out with self::$tab at the end

--- a/ast/pretty.go
+++ b/ast/pretty.go
@@ -41,7 +41,7 @@ func Pretty(sql string, method string) (output string) {
 
 	switch method {
 	case "builtin", "markdown":
-		return PrettyFormat(sql)
+		return format(sql)
 	default:
 		return sql
 	}
@@ -50,7 +50,7 @@ func Pretty(sql string, method string) (output string) {
 // format the whitespace in a SQL string to make it easier to read.
 // @param string  $query    The SQL string
 // @return String The SQL string with HTML styles and formatting wrapped in a <pre> tag
-func PrettyFormat(query string) string {
+func format(query string) string {
 	// This variable will be populated with formatted html
 	result := ""
 	// Use an actual tab while formatting and then switch out with self::$tab at the end


### PR DESCRIPTION
MergeAlterTables 方法更改为使用tidb解析器 解析SQL语句

修复vitess解析器无法解析rename语句 库名/表名的问题