### PR TITLE
修复引号中的注释判断

### DIFF
--- a/ast/testdata/TestSplitStatement.golden
+++ b/ast/testdata/TestSplitStatement.golden
@@ -40,6 +40,7 @@ tb;
 20 select /*!50000 1,*/ 1;
 21 UPDATE xxx SET c1=' LOGGER.error(""); }' WHERE id = 2 ;
 22 UPDATE `xxx` SET aaa='a;' WHERE `id` = 15;
+23 UPDATE `xxx` SET aaa='a -- b' WHERE `id` = 15;
 0 select * from test\G
 1 select 'hello\Gworld', col from test\G
 2 -- select * from test\Ghello

--- a/ast/token.go
+++ b/ast/token.go
@@ -863,12 +863,12 @@ func SplitStatement(buf []byte, delimiter []byte) (string, string, []byte) {
 		b := buf[i]
 		// single line comment
 		if b == '-' {
-			if i+2 < len(buf) && buf[i+1] == '-' && buf[i+2] == ' ' {
+			if !quoted && i+2 < len(buf) && buf[i+1] == '-' && buf[i+2] == ' ' {
 				singleLineComment = true
 				i = i + 2
 				continue
 			}
-			if i+2 < len(buf) && i == 0 && buf[i+1] == '-' && (buf[i+2] == '\n' || buf[i+2] == '\r') {
+			if !quoted && i+2 < len(buf) && i == 0 && buf[i+1] == '-' && (buf[i+2] == '\n' || buf[i+2] == '\r') {
 				sql = "--\n"
 				break
 			}

--- a/ast/token_test.go
+++ b/ast/token_test.go
@@ -173,7 +173,8 @@ select col from tb;
 		[]byte(`select /*!50000 1,*/ 1;`),                                          // 20
 		[]byte(`UPDATE xxx SET c1=' LOGGER.error(""); }' WHERE id = 2 ;`),          // 21
 		[]byte("UPDATE `xxx` SET aaa='a;' WHERE `id` = 15;"),                       // 22
-		// []byte(`/* comment here */ SET MAX_JOIN_SIZE=#`),                           // 23
+		[]byte("UPDATE `xxx` SET aaa='a -- b' WHERE `id` = 15; UPDATE `xxx` SET aaa='c -- d' WHERE `id` = 16;"), // 23
+		// []byte(`/* comment here */ SET MAX_JOIN_SIZE=#`),                        // 24
 	}
 	// \G 分隔符
 	buf2s := [][]byte{


### PR DESCRIPTION
引号中的双横线识别成了注释，比如```UPDATE `xxx` SET aaa='a -- b' WHERE `id` = 15;```