### PR TITLE
edit buffer_result

### DIFF
--- a/database/explain.go
+++ b/database/explain.go
@@ -152,6 +152,7 @@ type ExplainJSONNestedLoop struct {
 type ExplainJSONBufferResult struct {
 	UsingTemporaryTable bool                    `json:"using_temporary_table"`
 	NestedLoop          []ExplainJSONNestedLoop `json:"nested_loop"`
+	Table               ExplainJSONTable        `json:"table"`
 }
 
 // ExplainJSONSubqueries JSON


### PR DESCRIPTION
buffer_result 格式问题

使用的数据  test_db https://github.com/datacharmer/test_db.git 
sql 语句

select * from employees.salaries;
select sql_buffer_result * from employees.salaries;

explain  json


{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "289174.19"
    },
    "buffer_result": {
      "using_temporary_table": true,
      "table": {
        "table_name": "salaries",
        "access_type": "ALL",
        "rows_examined_per_scan": 2838426,
        "rows_produced_per_join": 2838426,
        "filtered": "100.00",
        "cost_info": {
          "read_cost": "5331.59",
          "eval_cost": "283842.60",
          "prefix_cost": "289174.19",
          "data_read_per_join": "43M"
        },
        "used_columns": [
          "emp_no",
          "salary",
          "from_date",
          "to_date"
        ]
      }
    }
  }
}
