### PR TITLE
edit OrderingOperation

### DIFF
--- a/database/explain.go
+++ b/database/explain.go
@@ -181,11 +181,12 @@ type ExplainJSONDuplicatesRemoval struct {
 
 // ExplainJSONOrderingOperation JSON
 type ExplainJSONOrderingOperation struct {
-	UsingFilesort     bool                         `json:"using_filesort"`
-	Table             ExplainJSONTable             `json:"table"`
-	DuplicatesRemoval ExplainJSONDuplicatesRemoval `json:"duplicates_removal"`
-	GroupingOperation ExplainJSONGroupingOperation `json:"grouping_operation"`
-	OrderbySubqueries []ExplainJSONSubqueries      `json:"order_by_subqueries"`
+	UsingFilesort           bool                         `json:"using_filesort"`
+	Table                   ExplainJSONTable             `json:"table"`
+	DuplicatesRemoval       ExplainJSONDuplicatesRemoval `json:"duplicates_removal"`
+	GroupingOperation       ExplainJSONGroupingOperation `json:"grouping_operation"`
+	OrderbySubqueries       []ExplainJSONSubqueries      `json:"order_by_subqueries"`
+	OptimizedAwaySubqueries []ExplainJSONSubqueries      `json:"optimized_away_subqueries"`
 }
 
 // ExplainJSONQueryBlock JSON


### PR DESCRIPTION
数据
使用的数据 test_db https://github.com/datacharmer/test_db.git

sql :

select emp_no, salary from employees.salaries order by (select max(salary) from employees.salaries)

explain json

{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "289174.19"
    },
    "ordering_operation": {
      "using_filesort": false,
      "table": {
        "table_name": "salaries",
        "access_type": "ALL",
        "rows_examined_per_scan": 2838426,
        "rows_produced_per_join": 2838426,
        "filtered": "100.00",
        "cost_info": {
          "read_cost": "5331.59",
          "eval_cost": "283842.60",
          "prefix_cost": "289174.19",
          "data_read_per_join": "43M"
        },
        "used_columns": [
          "emp_no",
          "salary"
        ]
      },
      "optimized_away_subqueries": [
        {
          "dependent": false,
          "cacheable": true,
          "query_block": {
            "select_id": 2,
            "cost_info": {
              "query_cost": "289174.19"
            },
            "table": {
              "table_name": "salaries",
              "access_type": "ALL",
              "rows_examined_per_scan": 2838426,
              "rows_produced_per_join": 2838426,
              "filtered": "100.00",
              "cost_info": {
                "read_cost": "5331.59",
                "eval_cost": "283842.60",
                "prefix_cost": "289174.19",
                "data_read_per_join": "43M"
              },
              "used_columns": [
                "salary"
              ]
            }
          }
        }
      ]
    }
  }
}
 