### PR TITLE
Update heuristic.go

### DIFF
--- a/advisor/heuristic.go
+++ b/advisor/heuristic.go
@@ -67,7 +67,7 @@ func (q *Query4Audit) RuleStarAlias() Rule {
 	tkns := ast.Tokenizer(q.Query)
 	for i, tkn := range tkns {
 		//TODO 省略不写AS的语法没有检查,原则上也需要检查
-		if tkn.Val == "*" && i+1 < len(tkns) && (tkns[i+1].Val == "as" || tkns[i+1].Type == sqlparser.ID {
+		if tkn.Val == "*" && i+1 < len(tkns) && (tkns[i+1].Val == "as" || tkns[i+1].Type == sqlparser.ID) {
 			rule = HeuristicRules["ALI.002"]
 		}
 	}

--- a/advisor/heuristic.go
+++ b/advisor/heuristic.go
@@ -66,7 +66,8 @@ func (q *Query4Audit) RuleStarAlias() Rule {
 	var rule = q.RuleOK()
 	tkns := ast.Tokenizer(q.Query)
 	for i, tkn := range tkns {
-		if tkn.Val == "*" && i+1 < len(tkns) && tkns[i+1].Val == "as" {
+		//TODO 省略不写AS的语法没有检查,原则上也需要检查
+		if tkn.Val == "*" && i+1 < len(tkns) && (tkns[i+1].Val == "as" || tkns[i+1].Type == sqlparser.ID {
 			rule = HeuristicRules["ALI.002"]
 		}
 	}


### PR DESCRIPTION
ALI.002: 不建议给列通配符'*'设置别名
通配符设置别名的语法有两种,一种是显示增加as关键词,一种是省略as关键词.但是本函数没有增加缺省as关键词的检查.
测试用例: select * col from city
