### PR TITLE
TestCase  TestRuleAlterCharset  bug fixed

### DIFF
--- a/advisor/heuristic_test.go
+++ b/advisor/heuristic_test.go
@@ -2727,13 +2727,14 @@ func TestRuleAlterCharset(t *testing.T) {
 			`ALTER TABLE tbl_name CHARACTER SET charset_name;`,
 			`ALTER TABLE t1 CHANGE a b BIGINT NOT NULL, character set utf8`,
 			`ALTER TABLE t1 CHANGE a b BIGINT NOT NULL,character set utf8`,
-			`alter table t1 convert to character set utf8 collate utf8_unicode_ci;`,
 			`alter table t1 default collate = utf8_unicode_ci;`,
 		},
 		{
 			// 反面的例子
 			`ALTER TABLE t MODIFY latin1_text_col TEXT CHARACTER SET utf8`,
 			`ALTER TABLE t1 CHANGE c1 c1 TEXT CHARACTER SET utf8;`,
+			//正规写法,不应该写在上面
+			`alter table t1 convert to character set utf8 collate utf8_unicode_ci;`,
 		},
 	}
 	for _, sql := range sqls[0] {


### PR DESCRIPTION
//不推荐写法
修改表的默认字符集:
ALTER TABLE table_name DEFAULT CHARACTER SET character_name;

//推荐写法
修改表字段的默认字符集:
ALTER TABLE table_name CHANGE field field field_type CHARACTER SET character_name [other_attribute]
修改表的默认字符集和所有列的字符集:
ALTER TABLE table_name CONVERT TO CHARACTER SET character_name

测试用例中SQL是推荐写法,SQL如下:
alter table t1 convert to character set utf8 collate utf8_unicode_ci;