### PR TITLE
Update index.go

### DIFF
--- a/advisor/index.go
+++ b/advisor/index.go
@@ -1132,6 +1132,10 @@ func DuplicateKeyChecker(conn *database.Connector, databases ...string) map[stri
 			for k1, cl1 := range idxMap {
 				for k2, cl2 := range idxMap {
 					if k1 != k2 && common.IsColsPart(cl1, cl2) {
+						//如果存在覆盖,但是被覆盖的是主键索引不进行删除操作,主键索引是不能被删除的
+						if k1 == "PRIMARY" || k2 == "PRIMARY" {
+							continue
+						}
 						hasDup = true
 						col1Str := common.JoinColumnsName(cl1, ", ")
 						col2Str := common.JoinColumnsName(cl2, ", ")


### PR DESCRIPTION
对索引进行重复检查
      如果存在对主键的组合索引覆盖主键索引,不建议对主键进行删除. 按照现在的逻辑会提示PRIMARY与idx_id_district重复.其实这种情况用户绝大多数是想利用“覆盖索引”加速

+-------+------------+---------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| dupt1 |          0 | PRIMARY             |            1 | ID          | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| dupt1 |          1 | CountryCode         |            1 | CountryCode | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| dupt1 |          1 | idx_name            |            1 | Name        | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| dupt1 |          1 | idx_name_coutrycode |            1 | Name        | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| dupt1 |          1 | idx_name_coutrycode |            2 | CountryCode | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| dupt1 |          1 | idx_id_district     |            1 | ID          | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| dupt1 |          1 | idx_id_district     |            2 | District    | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
+-------+------------+---------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+