### PR TITLE
fix bug of time parse by CleanupTestDatabase

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -172,7 +172,7 @@ func (vEnv *VirtualEnv) CleanupTestDatabase() {
 			continue
 		}
 		s := strings.Split(testDatabase, "_")
-		pastTime, err := time.Parse("060102150405", s[1])
+		pastTime, err := time.ParseInLocation("060102150405", s[1], time.Local)
 		if err != nil {
 			common.Log.Error("CleanupTestDatabase compute  pastTime Error: %s", err.Error())
 			continue


### PR DESCRIPTION
```shell
#the CMD: 
./soar -config=/src/github.com/XiaoMi/soar/etc/mysoar.yaml -cleanup-test-database

#before fixed:
 2022/01/12 20:16:27.727 [D] [mysql.go:92]  Execute SQL with DSN(127.0.0.1:3306/temptest) : select @@version
2022/01/12 20:16:27.732 [D] [mysql.go:92]  Execute SQL with DSN(11.80.15.53:3307/niffler) : select @@version
2022/01/12 20:16:27.997 [D] [env.go:154]  CleanupTestDatabase ...
2022/01/12 20:16:27.997 [D] [mysql.go:92]  Execute SQL with DSN(127.0.0.1:3306/temptest) : show databases like 'optimizer%'
## -6.74 less than 1 hours
2022/01/12 20:16:28.000 [D] [env.go:190]  CleanupTestDatabase by pass database optimizer_220112190045_njyvthlrfp7ymqdg, -6.74 less than 1 hours
2022/01/12 20:16:28.000 [D] [env.go:194]  CleanupTestDatabase done

#after fixed:
2022/01/12 21:02:06.093 [D] [mysql.go:92]  Execute SQL with DSN(127.0.0.1:3306/temptest) : select @@version
2022/01/12 21:02:06.097 [D] [mysql.go:92]  Execute SQL with DSN(11.80.15.53:3307/niffler) : select @@version
2022/01/12 21:02:06.305 [D] [env.go:154]  CleanupTestDatabase ...
2022/01/12 21:02:06.305 [D] [mysql.go:92]  Execute SQL with DSN(127.0.0.1:3306/temptest) : show databases like 'optimizer%'
## begin to drop database and success
2022/01/12 21:02:06.310 [D] [mysql.go:92]  Execute SQL with DSN(127.0.0.1:3306/temptest) : drop database optimizer_220112190045_njyvthlrfp7ymqdg
2022/01/12 21:02:06.341 [D] [env.go:187]  CleanupTestDatabase drop database optimizer_220112190045_njyvthlrfp7ymqdg success
2022/01/12 21:02:06.344 [D] [env.go:194]  CleanupTestDatabase done
```

**Reason ：**
there is a problem of '060102150405' by time.parse,  as the timeString is not have timezone, so it should be use time.ParseInLocation, if not, CleanupTestDatabase will delete db before 9 hours (if localzone is GMT+08:00)
```golang
func TestTemp(t *testing.T) {
	pastTime, _ := time.Parse("060102150405", "220112190045")
	fmt.Println(pastTime)
	now := time.Now()
	fmt.Println(now)
	subHour := time.Since(pastTime).Hours()
	fmt.Println(subHour)
	// output:
	//2022-01-12 19:00:45 +0000 UTC
	//2022-01-12 21:33:33.540297 +0800 CST m=+0.285287889
	//-5.453183249444445

	pastTime1, _ := time.ParseInLocation("060102150405", "220112190045", time.Local)
	fmt.Println(pastTime1)
	subHour1 := time.Since(pastTime1).Hours()
	fmt.Println(subHour1)
	// output:
	//2022-01-12 19:00:45 +0800 CST
	//2.5468167530555554
}
```

please have a look, thanks. @martianzhang 