### PR TITLE
alter table 修改字符集用convert to

### DIFF
--- a/advisor/heuristic.go
+++ b/advisor/heuristic.go
@@ -2793,7 +2793,7 @@ func (q *Query4Audit) RuleAlterCharset() Rule {
 							if option.Tp == tidb.TableOptionCharset ||
 								option.Tp == tidb.TableOptionCollate {
 								//增加CONVERT TO的判断
-								convertReg, _ := regexp.Compile("convert to")
+								convertReg, _ := regexp.Compile("convert\\b\\s+to")
 								if convertReg.Match([]byte(strings.ToLower(q.Query))) {
 									break
 								} else {


### PR DESCRIPTION
convert to匹配模式优化，允许两个单词中间有多个空格，如CONVERT_______TO


Code changes

convertReg, _ := regexp.Compile("convert to")
convertReg, _ := regexp.Compile("convert\\b\\s+to")
