### PR TITLE
add:新增配置项用于控制是否允许测试数据库版本小于线上数据库

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -51,19 +51,20 @@ var (
 // Configuration 配置文件定义结构体
 type Configuration struct {
 	// +++++++++++++++测试环境+++++++++++++++++
-	OnlineDSN               *Dsn   `yaml:"online-dsn"`                // 线上环境数据库配置
-	TestDSN                 *Dsn   `yaml:"test-dsn"`                  // 测试环境数据库配置
-	AllowOnlineAsTest       bool   `yaml:"allow-online-as-test"`      // 允许 Online 环境也可以当作 Test 环境
-	DropTestTemporary       bool   `yaml:"drop-test-temporary"`       // 是否清理Test环境产生的临时库表
-	CleanupTestDatabase     bool   `yaml:"cleanup-test-database"`     // 清理残余的测试数据库（程序异常退出或未开启drop-test-temporary）  issue #48
-	OnlySyntaxCheck         bool   `yaml:"only-syntax-check"`         // 只做语法检查不输出优化建议
-	SamplingStatisticTarget int    `yaml:"sampling-statistic-target"` // 数据采样因子，对应 PostgreSQL 的 default_statistics_target
-	Sampling                bool   `yaml:"sampling"`                  // 数据采样开关
-	SamplingCondition       string `yaml:"sampling-condition"`        // 指定采样条件，如：WHERE xxx LIMIT xxx;
-	Profiling               bool   `yaml:"profiling"`                 // 在开启数据采样的情况下，在测试环境执行进行profile
-	Trace                   bool   `yaml:"trace"`                     // 在开启数据采样的情况下，在测试环境执行进行Trace
-	Explain                 bool   `yaml:"explain"`                   // Explain开关
-	Delimiter               string `yaml:"delimiter"`                 // SQL分隔符
+	OnlineDSN                   *Dsn   `yaml:"online-dsn"`                       // 线上环境数据库配置
+	TestDSN                     *Dsn   `yaml:"test-dsn"`                         // 测试环境数据库配置
+	AllowOnlineAsTest           bool   `yaml:"allow-online-as-test"`             // 允许 Online 环境也可以当作 Test 环境
+	AllowTestVerOlderThanOnline bool   `yaml:"allow-test-ver-older-than-online"` // 允许测试环境版本低于线上环境 不建议开启，可能会导致语句执行异常
+	DropTestTemporary           bool   `yaml:"drop-test-temporary"`              // 是否清理Test环境产生的临时库表
+	CleanupTestDatabase         bool   `yaml:"cleanup-test-database"`            // 清理残余的测试数据库（程序异常退出或未开启drop-test-temporary）  issue #48
+	OnlySyntaxCheck             bool   `yaml:"only-syntax-check"`                // 只做语法检查不输出优化建议
+	SamplingStatisticTarget     int    `yaml:"sampling-statistic-target"`        // 数据采样因子，对应 PostgreSQL 的 default_statistics_target
+	Sampling                    bool   `yaml:"sampling"`                         // 数据采样开关
+	SamplingCondition           string `yaml:"sampling-condition"`               // 指定采样条件，如：WHERE xxx LIMIT xxx;
+	Profiling                   bool   `yaml:"profiling"`                        // 在开启数据采样的情况下，在测试环境执行进行profile
+	Trace                       bool   `yaml:"trace"`                            // 在开启数据采样的情况下，在测试环境执行进行Trace
+	Explain                     bool   `yaml:"explain"`                          // Explain开关
+	Delimiter                   string `yaml:"delimiter"`                        // SQL分隔符
 
 	// +++++++++++++++日志相关+++++++++++++++++
 	// 日志级别，这里使用了 beego 的 log 包

--- a/doc/config.md
+++ b/doc/config.md
@@ -23,6 +23,8 @@ test-dsn:
   disable: false
 # 是否允许测试环境与线上环境配置相同
 allow-online-as-test: true
+# 是否允许测试环境数据库版本小于线上环境
+allow-test-ver-older-than-online: false
 # 是否清理测试时产生的临时文件
 drop-test-temporary: true
 # 语法检查小工具

--- a/env/env.go
+++ b/env/env.go
@@ -99,10 +99,13 @@ func BuildEnv() (*VirtualEnv, *database.Connector) {
 		common.Config.OnlineDSN.Disable = true
 	}
 
-	// 判断测试环境与线上环境版本是否一致，要求测试环境版本不低于线上环境
-	if vEnvVersion < rEnvVersion {
-		common.Log.Warning("TestDSN MySQL version older than OnlineDSN(%d), TestDSN(%d) will not be used", rEnvVersion, vEnvVersion)
-		common.Config.TestDSN.Disable = true
+	// 检查是否允许测试环境版本小于线上环境版本
+	if !common.Config.AllowTestVerOlderThanOnline {
+		// 判断测试环境与线上环境版本是否一致，要求测试环境版本不低于线上环境
+		if vEnvVersion < rEnvVersion {
+			common.Log.Warning("TestDSN MySQL version older than OnlineDSN(%d), TestDSN(%d) will not be used", rEnvVersion, vEnvVersion)
+			common.Config.TestDSN.Disable = true
+		}
 	}
 
 	return vEnv, connOnline

--- a/etc/soar.yaml
+++ b/etc/soar.yaml
@@ -15,6 +15,7 @@ test-dsn:
 
 # 高危，仅测试时使用，线上环境禁止配置为 true
 allow-online-as-test: true
+allow-test-ver-older-than-online: false
 column-not-allow-type:
 - json
 - text


### PR DESCRIPTION
新增配置项用于控制是否允许测试数据库版本小于线上数据库

Log: 新增配置项用于控制是否允许测试数据库版本小于线上数据库

<!--
Thank you for contributing to SOAR! Please read SOAR's [CONTRIBUTING](https://github.com/XiaoMi/soar/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
个人认为测试数据库和线上数据库的版本对比需要做成配置项，否则无法兼容MariaDB等类型数据库


