### PR TITLE
perf: delete redundant judgments of config arg

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -995,12 +995,6 @@ func ArgConfig() string {
 			// -config=soar.yaml
 			configFile = strings.Split(os.Args[1], "=")[1]
 		}
-	} else {
-		for i, c := range os.Args {
-			if strings.HasPrefix(c, "-config") && i != 1 {
-				fmt.Println("-config must be the first arg")
-			}
-		}
 	}
 	return configFile
 }


### PR DESCRIPTION
### What problem does this PR solve? 
delete redundant judgments of config arg.
It has been ensured in the `initConfig()`  that if the `- config` parameter exists, it must be first parameter. So in the `common.ArgConfig`, it is no need to check again.
